### PR TITLE
refactor(panda-pulse): multiple jobs if cl/el arrays passed

### DIFF
--- a/charts/panda-pulse/Chart.yaml
+++ b/charts/panda-pulse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: panda-pulse
 description: A Helm chart for Panda Pulse - Ethereum network monitoring and reporting tool
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "latest"
 maintainers:
   - name: matty

--- a/charts/panda-pulse/README.md
+++ b/charts/panda-pulse/README.md
@@ -1,6 +1,6 @@
 # panda-pulse
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Panda Pulse - Ethereum network monitoring and reporting tool
 
@@ -16,8 +16,8 @@ A Helm chart for Panda Pulse - Ethereum network monitoring and reporting tool
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config.discordChannel | string | `"YOUR_DISCORD_CHANNEL_ID"` |  |
-| config.ethereumCl | string | `""` |  |
-| config.ethereumEl | string | `""` |  |
+| config.ethereumCls | list | `[]` |  |
+| config.ethereumEls | list | `[]` |  |
 | config.grafanaBaseUrl | string | `""` |  |
 | config.network | string | `"YOUR_PREFERRED_NETWORK"` |  |
 | config.prometheusDatasourceId | string | `""` |  |

--- a/charts/panda-pulse/templates/cronjob.yaml
+++ b/charts/panda-pulse/templates/cronjob.yaml
@@ -1,3 +1,172 @@
+{{- if or .Values.config.ethereumCls .Values.config.ethereumEls }}
+{{- range .Values.config.ethereumCls }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "panda-pulse.fullname" $ }}-cl-{{ . | lower }}
+  labels:
+    {{- include "panda-pulse.labels" $ | nindent 4 }}
+    ethereum-client-type: cl
+    ethereum-client: {{ . | lower }}
+spec:
+  schedule: {{ $.Values.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- with $.Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "panda-pulse.selectorLabels" $ | nindent 12 }}
+            ethereum-client-type: cl
+            ethereum-client: {{ . | lower }}
+        spec:
+          {{- with $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "panda-pulse.serviceAccountName" $ }}
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: {{ $.Chart.Name }}
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+              imagePullPolicy: {{ $.Values.image.pullPolicy }}
+              args:
+                - --network={{ required "A valid network is required" $.Values.config.network }}
+                - --discord-channel={{ required "A valid Discord channel ID is required" $.Values.config.discordChannel }}
+                - --ethereum-cl={{ . }}
+                {{- if $.Values.config.grafanaBaseUrl }}
+                - --grafana-base-url={{ $.Values.config.grafanaBaseUrl }}
+                {{- end }}
+                {{- if $.Values.config.prometheusDatasourceId }}
+                - --prometheus-datasource-id={{ $.Values.config.prometheusDatasourceId }}
+                {{- end }}
+              env:
+                - name: GRAFANA_SERVICE_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "panda-pulse.fullname" $ }}
+                      key: grafana-service-token
+                - name: DISCORD_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "panda-pulse.fullname" $ }}
+                      key: discord-bot-token
+                {{- if $.Values.secrets.openrouterApiKey }}
+                - name: OPENROUTER_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "panda-pulse.fullname" $ }}
+                      key: openrouter-api-key
+                {{- end }}
+              resources:
+                {{- toYaml $.Values.resources | nindent 16 }}
+          {{- with $.Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          restartPolicy: OnFailure
+{{- end }}
+{{- range .Values.config.ethereumEls }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "panda-pulse.fullname" $ }}-el-{{ . | lower }}
+  labels:
+    {{- include "panda-pulse.labels" $ | nindent 4 }}
+    ethereum-client-type: el
+    ethereum-client: {{ . | lower }}
+spec:
+  schedule: {{ $.Values.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- with $.Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "panda-pulse.selectorLabels" $ | nindent 12 }}
+            ethereum-client-type: el
+            ethereum-client: {{ . | lower }}
+        spec:
+          {{- with $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "panda-pulse.serviceAccountName" $ }}
+          securityContext:
+            {{- toYaml $.Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: {{ $.Chart.Name }}
+              securityContext:
+                {{- toYaml $.Values.securityContext | nindent 16 }}
+              image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+              imagePullPolicy: {{ $.Values.image.pullPolicy }}
+              args:
+                - --network={{ required "A valid network is required" $.Values.config.network }}
+                - --discord-channel={{ required "A valid Discord channel ID is required" $.Values.config.discordChannel }}
+                - --ethereum-el={{ . }}
+                {{- if $.Values.config.grafanaBaseUrl }}
+                - --grafana-base-url={{ $.Values.config.grafanaBaseUrl }}
+                {{- end }}
+                {{- if $.Values.config.prometheusDatasourceId }}
+                - --prometheus-datasource-id={{ $.Values.config.prometheusDatasourceId }}
+                {{- end }}
+              env:
+                - name: GRAFANA_SERVICE_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "panda-pulse.fullname" $ }}
+                      key: grafana-service-token
+                - name: DISCORD_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "panda-pulse.fullname" $ }}
+                      key: discord-bot-token
+                {{- if $.Values.secrets.openrouterApiKey }}
+                - name: OPENROUTER_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "panda-pulse.fullname" $ }}
+                      key: openrouter-api-key
+                {{- end }}
+              resources:
+                {{- toYaml $.Values.resources | nindent 16 }}
+          {{- with $.Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          restartPolicy: OnFailure
+{{- end }}
+{{- else }}
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -34,12 +203,6 @@ spec:
               args:
                 - --network={{ required "A valid network is required" .Values.config.network }}
                 - --discord-channel={{ required "A valid Discord channel ID is required" .Values.config.discordChannel }}
-                {{- if .Values.config.ethereumCl }}
-                - --ethereum-cl={{ .Values.config.ethereumCl }}
-                {{- end }}
-                {{- if .Values.config.ethereumEl }}
-                - --ethereum-el={{ .Values.config.ethereumEl }}
-                {{- end }}
                 {{- if .Values.config.grafanaBaseUrl }}
                 - --grafana-base-url={{ .Values.config.grafanaBaseUrl }}
                 {{- end }}
@@ -78,4 +241,5 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          restartPolicy: OnFailure 
+          restartPolicy: OnFailure
+{{- end }}

--- a/charts/panda-pulse/values.yaml
+++ b/charts/panda-pulse/values.yaml
@@ -12,8 +12,8 @@ schedule: "0 7 * * *"  # Run at 7am UTC daily
 config:
   network: "YOUR_PREFERRED_NETWORK"  # required
   discordChannel: "YOUR_DISCORD_CHANNEL_ID"  # required
-  ethereumCl: ""  # optional
-  ethereumEl: ""  # optional
+  ethereumCls: []  # array of CL clients to monitor
+  ethereumEls: []  # array of EL clients to monitor
   grafanaBaseUrl: ""  # optional
   prometheusDatasourceId: ""  # optional
 


### PR DESCRIPTION
Refactors chart to allow passing of an _optional_ array of `ethereumCls` and/or `ethereumEls`.

If `ethereumCls` + `ethereumEls` are both omitted, then a single cron will be created as normal capturing all clients.

For example:

```bash
helm install panda-pulse ./charts/panda-pulse \
  --set config.network=NETWORK_NAME_HERE \
  --set config.discordChannel=DISCORD_CHANNEL_ID_HERE \
  --set config.ethereumCls="{lighthouse,nimbus}" \
  --set config.ethereumEls="{geth,reth}" \
  --set secrets.grafanaServiceToken=GRAFANA_SERVICE_TOKEN_HERE \
  --set secrets.discordBotToken=DISCORD_BOT_TOKEN_HERE
```

```bash
NAME                        SCHEDULE      TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
panda-pulse-cl-lighthouse   0/2 * * * *   <none>     False     0        <none>          3s
panda-pulse-cl-nimbus       0/2 * * * *   <none>     False     0        <none>          3s
panda-pulse-el-geth         0/2 * * * *   <none>     False     0        <none>          3s
panda-pulse-el-reth         0/2 * * * *   <none>     False     0        <none>          3s
```