### PR TITLE
feat(charts): add github token support to helm chart

### DIFF
--- a/charts/panda-pulse/Chart.yaml
+++ b/charts/panda-pulse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: panda-pulse
 description: A Helm chart for Panda Pulse - Ethereum network monitoring and reporting tool
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "latest"
 maintainers:
   - name: matty

--- a/charts/panda-pulse/README.md
+++ b/charts/panda-pulse/README.md
@@ -1,6 +1,6 @@
 # panda-pulse
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A Helm chart for Panda Pulse - Ethereum network monitoring and reporting tool
 
@@ -55,6 +55,7 @@ A Helm chart for Panda Pulse - Ethereum network monitoring and reporting tool
 | resources.requests.cpu | string | `"100m"` |  |
 | resources.requests.memory | string | `"128Mi"` |  |
 | secrets.discordBotToken | string | `"YOUR_DISCORD_BOT_TOKEN"` |  |
+| secrets.githubToken | string | `"YOUR_GITHUB_TOKEN"` |  |
 | secrets.grafanaServiceToken | string | `"YOUR_GRAFANA_SERVICE_TOKEN"` |  |
 | secrets.s3AccessKeyId | string | `"YOUR_S3_ACCESS_KEY_ID"` |  |
 | secrets.s3SecretAccessKey | string | `"YOUR_S3_SECRET_ACCESS_KEY"` |  |

--- a/charts/panda-pulse/templates/deployment.yaml
+++ b/charts/panda-pulse/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "panda-pulse.fullname" . }}
+                  key: github-token
             - name: GRAFANA_SERVICE_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/panda-pulse/templates/secret.yaml
+++ b/charts/panda-pulse/templates/secret.yaml
@@ -10,3 +10,4 @@ data:
   discord-bot-token: {{ required "A valid Discord bot token is required" .Values.secrets.discordBotToken | b64enc }}
   aws-access-key-id: {{ required "A valid S3 Access Key ID is required" .Values.secrets.s3AccessKeyId | b64enc }}
   aws-secret-access-key: {{ required "A valid S3 Secret Access Key is required" .Values.secrets.s3SecretAccessKey | b64enc }} 
+  github-token: {{ required "A valid Github token is required" .Values.secrets.githubToken | b64enc }}

--- a/charts/panda-pulse/values.yaml
+++ b/charts/panda-pulse/values.yaml
@@ -23,6 +23,7 @@ secrets:
   discordBotToken: "YOUR_DISCORD_BOT_TOKEN"  # required
   s3AccessKeyId: "YOUR_S3_ACCESS_KEY_ID"  # required
   s3SecretAccessKey: "YOUR_S3_SECRET_ACCESS_KEY"  # required
+  githubToken: "YOUR_GITHUB_TOKEN" # required
 
 resources:
   limits:


### PR DESCRIPTION
This commit introduces the ability to configure a GitHub token via the Helm chart. This token can be used for accessing GitHub resources.

The following changes were made:

- Updated Chart.yaml to increment the chart version to 1.0.2.
- Updated README.md to reflect the new chart version and document the new `secrets.githubToken` value.
- Modified the secret.yaml template to include the `github-token` secret.
- Modified the deployment.yaml template to inject the `GITHUB_TOKEN` environment variable from the secret.
- Added a `secrets.githubToken` value to values.yaml.