### PR TITLE
feat(chproxy): add hostNetwork and dnsPolicy support

### DIFF
--- a/charts/chproxy/Chart.yaml
+++ b/charts/chproxy/Chart.yaml
@@ -3,7 +3,7 @@ name: chproxy
 description: HTTP proxy and load balancer for ClickHouse
 home: https://www.chproxy.org
 type: application
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: savid
     email: andrew.davis@ethereum.org

--- a/charts/chproxy/README.md
+++ b/charts/chproxy/README.md
@@ -1,7 +1,7 @@
 
 # chproxy
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 HTTP proxy and load balancer for ClickHouse
 
@@ -34,6 +34,7 @@ HTTP proxy and load balancer for ClickHouse
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customArgs | list | `[]` | Custom args for the chproxy container |
 | customCommand | list | `[]` | Command replacement for the chproxy container |
+| dnsPolicy | string | `"ClusterFirst"` | DNS policy for the pod (set to ClusterFirstWithHostNet when using hostNetwork) |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
 | extraPodPorts | list | `[]` | Extra Pod ports |
@@ -41,6 +42,7 @@ HTTP proxy and load balancer for ClickHouse
 | extraVolumeMounts | list | `[]` | Additional volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| hostNetwork | bool | `false` | Enable host networking for the pod |
 | image.pullPolicy | string | `"IfNotPresent"` | chproxy container pull policy |
 | image.repository | string | `"contentsquareplatform/chproxy"` | chproxy container image repository |
 | image.tag | string | `"v1.26.5"` | chproxy container image tag |

--- a/charts/chproxy/templates/deployment.yaml
+++ b/charts/chproxy/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "chproxy.serviceAccountName" . }}
+    {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+    {{- end }}
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}

--- a/charts/chproxy/values.yaml
+++ b/charts/chproxy/values.yaml
@@ -80,6 +80,12 @@ service:
   # -- Service type
   type: ClusterIP
 
+# -- Enable host networking for the pod
+hostNetwork: false
+
+# -- DNS policy for the pod (set to ClusterFirstWithHostNet when using hostNetwork)
+dnsPolicy: ClusterFirst
+
 # -- Affinity configuration for pods
 affinity: {}
 


### PR DESCRIPTION
## Summary

- Add `hostNetwork` and `dnsPolicy` values to the chproxy Helm chart
- When `hostNetwork: true`, the deployment pod spec gets `hostNetwork: true` and `dnsPolicy` set (defaults to `ClusterFirstWithHostNet` for kube DNS access)
- Bump chart version from `0.0.1` to `0.0.2`

## Changes

| File | Change |
|---|---|
| `charts/chproxy/values.yaml` | Added `hostNetwork: false` and `dnsPolicy: ClusterFirst` defaults |
| `charts/chproxy/templates/deployment.yaml` | Conditionally render `hostNetwork` and `dnsPolicy` in pod spec |
| `charts/chproxy/Chart.yaml` | Version bump `0.0.1` → `0.0.2` |

## Usage

```yaml
chproxy:
  hostNetwork: true
  dnsPolicy: ClusterFirstWithHostNet
```

No-op by default — `hostNetwork: false` means existing deployments are unaffected.