### PR TITLE
feat(chart): add clickhouse-movoor chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ helm search repo ethpandaops-general-helm-charts
 - [`asynqmon`](charts/asynqmon)
 - [`cbt`](charts/cbt)
 - [`chproxy`](charts/chproxy)
+- [`clickhouse-movoor`](charts/clickhouse-movoor)
 - [`cloudflare-tunnel`](charts/cloudflare-tunnel)
 - [`dispatchoor-api`](charts/dispatchoor-api)
 - [`dispatchoor-ui`](charts/dispatchoor-ui)
 - [`panda-pulse`](charts/panda-pulse)
 - [`raw-configmap`](charts/raw-configmap)
+- [`wagie`](charts/wagie)
 
 ## Development
 

--- a/charts/clickhouse-movoor/.helmignore
+++ b/charts/clickhouse-movoor/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/clickhouse-movoor/.helmignore
+++ b/charts/clickhouse-movoor/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Chart-testing CI values
+ci/

--- a/charts/clickhouse-movoor/Chart.yaml
+++ b/charts/clickhouse-movoor/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: clickhouse-movoor
+description: A ClickHouse storage tiering operator that moves cold MergeTree partitions to colder disks
+home: https://github.com/ethpandaops/clickhouse-movoor
+type: application
+version: 0.0.1
+maintainers:
+  - name: savid
+    email: andrew.davis@ethereum.org

--- a/charts/clickhouse-movoor/README.md
+++ b/charts/clickhouse-movoor/README.md
@@ -1,0 +1,87 @@
+# clickhouse-movoor
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A ClickHouse storage tiering operator that moves cold MergeTree partitions to colder disks
+
+**Homepage:** <https://github.com/ethpandaops/clickhouse-movoor>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| savid | andrew.davis@ethereum.org |  |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration for pods |
+| annotations | object | `{}` | Annotations for the StatefulSet |
+| args | list | `[]` | Command arguments |
+| config.clickhouse.dialTimeout | string | `"5s"` | Dial timeout (standard Go duration) |
+| config.clickhouse.nodes | list | See `values.yaml` | ClickHouse nodes (required). Each entry is one physical ClickHouse node, do not use comma-separated failover DSNs or load-balanced addresses here. DSNs are environment-expanded, so ${CLICKHOUSE_PASSWORD} injected via secretEnv is supported |
+| config.clickhouse.queryTimeout | string | `"30s"` | Query timeout (standard Go duration) |
+| config.frontend.addr | string | `":8080"` | Address to serve the frontend on |
+| config.frontend.enabled | bool | `true` | Enable or disable the frontend UI/API service |
+| config.healthCheckAddr | string | `":8081"` | Health check server address |
+| config.logging | string | `"info"` | Logging level: debug, info, warn/warning, or error |
+| config.metricsAddr | string | `":9090"` | Metrics server address |
+| config.tiering.defaults | object | See `values.yaml` | Defaults copied into every watch that has a tier block. A watch without a tier block remains observe-only |
+| config.tiering.interval | string | `"5m"` | Pause between reconcile cycles |
+| config.tiering.mode | string | `"plan"` | Tiering mode. "off" observes only, plan computes decisions without ALTERs, enforce applies movement/optimization decisions |
+| config.watches | list | `[]` | Tables to watch. A watch without a tier block is observe-only |
+| containerSecurityContext | object | See `values.yaml` | The security context for containers |
+| customArgs | list | `[]` | Custom args for the clickhouse-movoor container |
+| customCommand | list | `[]` | Command replacement for the clickhouse-movoor container |
+| extraContainers | list | `[]` | Additional containers |
+| extraEnv | list | `[]` | Additional env variables |
+| extraPodPorts | list | `[]` | Extra Pod ports |
+| extraPorts | list | `[]` | Additional ports. Useful when using extraContainers |
+| extraVolumeMounts | list | `[]` | Additional volume mounts |
+| extraVolumes | list | `[]` | Additional volumes |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| image.pullPolicy | string | `"IfNotPresent"` | clickhouse-movoor container pull policy |
+| image.repository | string | `"ethpandaops/clickhouse-movoor"` | clickhouse-movoor container image repository |
+| image.tag | string | `"latest"` | clickhouse-movoor container image tag |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| ingress.http.annotations | object | `{}` | Annotations for Ingress |
+| ingress.http.className | string | `""` |  |
+| ingress.http.enabled | bool | `false` | Ingress resource for the HTTP frontend |
+| ingress.http.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]` | Ingress host |
+| ingress.http.tls | list | `[]` | Ingress TLS |
+| initContainers | list | `[]` | Additional init containers |
+| lifecycle | object | `{}` | Lifecycle hooks. The default image is distroless, so exec hooks like /bin/sleep are not available |
+| livenessProbe | object | See `values.yaml` | Liveness probe |
+| nameOverride | string | `""` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector for pods |
+| podAnnotations | object | `{}` | Pod annotations |
+| podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec If not set then a PodDisruptionBudget will not be created |
+| podLabels | object | `{}` | Pod labels |
+| priorityClassName | string | `nil` | Pod priority class |
+| readinessProbe | object | See `values.yaml` | Readiness probe |
+| replicas | int | `1` | Number of replicas. clickhouse-movoor is a singleton operator, you almost certainly want to keep this at 1 |
+| resources | object | `{}` | Resource requests and limits |
+| secretEnv | object | `{}` | Secret env variables injected via a created secret. DSNs in the config are environment-expanded, so you can keep credentials out of the config, e.g. CLICKHOUSE_PASSWORD referenced as ${CLICKHOUSE_PASSWORD} |
+| securityContext | object | See `values.yaml` | The security context for pods |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
+| serviceMonitor.interval | string | `"15s"` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
+| serviceMonitor.path | string | `"/metrics"` | Path to scrape |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabelings |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
+| serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
+| serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
+| terminationGracePeriodSeconds | int | `60` | How long to wait until the pod is forcefully terminated |
+| tolerations | list | `[]` | Tolerations for pods |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pods |
+| updateStrategy | object | See `values.yaml` | Update strategy for the StatefulSet |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/clickhouse-movoor/ci/ct-values.yaml
+++ b/charts/clickhouse-movoor/ci/ct-values.yaml
@@ -1,0 +1,14 @@
+# Values used by chart-testing (ct install) in CI.
+# There is no ClickHouse in the CI cluster. movoor tolerates unreachable nodes
+# (logs reachability warnings and keeps serving /healthz with HTTP 200), but
+# config validation requires at least one watch, so provide a dummy one.
+config:
+  clickhouse:
+    nodes:
+      - name: ci-smoke-test
+        shard: "0"
+        replica: "0"
+        dsn: "clickhouse://default@clickhouse:9000/default"
+  watches:
+    - database: default
+      table: ci_smoke_test

--- a/charts/clickhouse-movoor/templates/NOTES.txt
+++ b/charts/clickhouse-movoor/templates/NOTES.txt
@@ -1,0 +1,19 @@
+clickhouse-movoor has been deployed successfully!
+
+Exposed services:
+- Metrics: {{ include "clickhouse-movoor.metricsPort" . }}
+{{- if (include "clickhouse-movoor.frontendPort" .) }}
+- Frontend: {{ include "clickhouse-movoor.frontendPort" . }}
+{{- end }}
+{{- if (include "clickhouse-movoor.probePort" .) }}
+- Health check: {{ include "clickhouse-movoor.probePort" . }}
+{{- end }}
+
+{{- if contains "ClusterIP" .Values.service.type }}
+
+To access the services, use port-forwarding:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "clickhouse-movoor.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+{{- if (include "clickhouse-movoor.frontendPort" .) }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ include "clickhouse-movoor.frontendPort" . }}:{{ include "clickhouse-movoor.frontendPort" . }}
+{{- end }}
+{{- end }}

--- a/charts/clickhouse-movoor/templates/_helpers.tpl
+++ b/charts/clickhouse-movoor/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clickhouse-movoor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "clickhouse-movoor.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "clickhouse-movoor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "clickhouse-movoor.labels" -}}
+helm.sh/chart: {{ include "clickhouse-movoor.chart" . }}
+{{ include "clickhouse-movoor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "clickhouse-movoor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "clickhouse-movoor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "clickhouse-movoor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "clickhouse-movoor.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "clickhouse-movoor.metricsPort" -}}
+{{ (split ":" .Values.config.metricsAddr)._1 | default "9090" }}
+{{- end -}}
+
+{{- define "clickhouse-movoor.probePort" -}}
+{{- if .Values.config.healthCheckAddr -}}
+{{- if hasPrefix ":" .Values.config.healthCheckAddr -}}
+{{ trimPrefix ":" .Values.config.healthCheckAddr }}
+{{- else -}}
+{{ .Values.config.healthCheckAddr }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "clickhouse-movoor.frontendPort" -}}
+{{- if .Values.config.frontend.enabled -}}
+{{ (split ":" .Values.config.frontend.addr)._1 | default "8080" }}
+{{- end -}}
+{{- end -}}

--- a/charts/clickhouse-movoor/templates/configmap.yaml
+++ b/charts/clickhouse-movoor/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickhouse-movoor.fullname" . }}
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    {{ toYaml .Values.config | nindent 4 }}

--- a/charts/clickhouse-movoor/templates/ingress.yaml
+++ b/charts/clickhouse-movoor/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.http.enabled -}}
+{{- $fullName := include "clickhouse-movoor.fullname" . -}}
+{{- $svcPort := include "clickhouse-movoor.frontendPort" . -}}
+{{- if and .Values.ingress.http.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.http.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.http.annotations "kubernetes.io/ingress.class" .Values.ingress.http.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+  {{- with .Values.ingress.http.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.http.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.http.className }}
+  {{- end }}
+  {{- if .Values.ingress.http.tls }}
+  tls:
+    {{- range .Values.ingress.http.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.http.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/clickhouse-movoor/templates/pdb.yaml
+++ b/charts/clickhouse-movoor/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "clickhouse-movoor.fullname" . }}
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "clickhouse-movoor.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+{{- end -}}

--- a/charts/clickhouse-movoor/templates/secret.yaml
+++ b/charts/clickhouse-movoor/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "clickhouse-movoor.fullname" . }}-env
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+data:
+{{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | b64enc }}
+{{- end }}

--- a/charts/clickhouse-movoor/templates/service-headless.yaml
+++ b/charts/clickhouse-movoor/templates/service-headless.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse-movoor.fullname" . }}-headless
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ include "clickhouse-movoor.metricsPort" . }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- if (include "clickhouse-movoor.probePort" .) }}
+    - port: {{ include "clickhouse-movoor.probePort" . }}
+      targetPort: probe
+      protocol: TCP
+      name: probe
+    {{- end }}
+    {{- if (include "clickhouse-movoor.frontendPort" .) }}
+    - port: {{ include "clickhouse-movoor.frontendPort" . }}
+      targetPort: frontend
+      protocol: TCP
+      name: frontend
+    {{- end }}
+  selector:
+    {{- include "clickhouse-movoor.selectorLabels" . | nindent 4 }}

--- a/charts/clickhouse-movoor/templates/service.yaml
+++ b/charts/clickhouse-movoor/templates/service.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "clickhouse-movoor.fullname" . }}
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ include "clickhouse-movoor.metricsPort" . }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- if (include "clickhouse-movoor.probePort" .) }}
+    - port: {{ include "clickhouse-movoor.probePort" . }}
+      targetPort: probe
+      protocol: TCP
+      name: probe
+    {{- end }}
+    {{- if (include "clickhouse-movoor.frontendPort" .) }}
+    - port: {{ include "clickhouse-movoor.frontendPort" . }}
+      targetPort: frontend
+      protocol: TCP
+      name: frontend
+    {{- end }}
+  {{- if .Values.extraPorts }}
+    {{ toYaml .Values.extraPorts | nindent 4}}
+  {{- end }}
+  selector:
+    {{- include "clickhouse-movoor.selectorLabels" . | nindent 4 }}

--- a/charts/clickhouse-movoor/templates/serviceaccount.yaml
+++ b/charts/clickhouse-movoor/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "clickhouse-movoor.serviceAccountName" . }}
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/clickhouse-movoor/templates/servicemonitor.yaml
+++ b/charts/clickhouse-movoor/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "clickhouse-movoor.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+  {{ toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: metrics
+    path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+    {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "clickhouse-movoor.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/clickhouse-movoor/templates/statefulset.yaml
+++ b/charts/clickhouse-movoor/templates/statefulset.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "clickhouse-movoor.fullname" . }}
+  labels:
+    {{- include "clickhouse-movoor.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  serviceName: {{ include "clickhouse-movoor.fullname" . }}-headless
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "clickhouse-movoor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "clickhouse-movoor.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "clickhouse-movoor.serviceAccountName" . }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        {{- if gt (len .Values.customCommand) 0 }}
+          {{- toYaml .Values.customCommand | nindent 12}}
+        {{- else }}
+          - "/usr/local/bin/clickhouse-movoor"
+          - --config=/config.yaml
+          {{- if gt (len .Values.args) 0 }}
+          {{- toYaml .Values.args | nindent 12}}
+          {{- end }}
+        {{- end }}
+        {{- if gt (len .Values.customArgs) 0 }}
+        args:
+          {{- toYaml .Values.customArgs | nindent 12}}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        volumeMounts:
+          - name: config
+            mountPath: "/config.yaml"
+            subPath: config.yaml
+            readOnly: true
+          {{- if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
+          {{- end }}
+        ports:
+          - name: metrics
+            containerPort: {{ include "clickhouse-movoor.metricsPort" . }}
+            protocol: TCP
+          {{- if (include "clickhouse-movoor.probePort" .) }}
+          - name: probe
+            containerPort: {{ include "clickhouse-movoor.probePort" . }}
+            protocol: TCP
+          {{- end }}
+          {{- if (include "clickhouse-movoor.frontendPort" .) }}
+          - name: frontend
+            containerPort: {{ include "clickhouse-movoor.frontendPort" . }}
+            protocol: TCP
+          {{- end }}
+          {{- if .Values.extraPodPorts }}
+            {{ toYaml .Values.extraPodPorts | nindent 10 }}
+          {{- end }}
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 12 }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 12 }}
+        {{- with .Values.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        env:
+        {{- range $key, $value := .Values.secretEnv }}
+          - name: {{ $key }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "clickhouse-movoor.fullname" $ }}-env
+                key: {{ $key }}
+        {{- end }}
+        {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 12 }}
+        {{- end }}
+      {{- if .Values.extraContainers }}
+        {{ toYaml .Values.extraContainers | nindent 8}}
+      {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      volumes:
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 8}}
+      {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "clickhouse-movoor.fullname" . }}

--- a/charts/clickhouse-movoor/values.yaml
+++ b/charts/clickhouse-movoor/values.yaml
@@ -1,0 +1,255 @@
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+# -- Number of replicas. clickhouse-movoor is a singleton operator, you almost
+# certainly want to keep this at 1
+replicas: 1
+
+image:
+  # -- clickhouse-movoor container image repository
+  repository: ethpandaops/clickhouse-movoor
+  # -- clickhouse-movoor container image tag
+  tag: latest
+  # -- clickhouse-movoor container pull policy
+  pullPolicy: IfNotPresent
+
+# -- Secret env variables injected via a created secret.
+# DSNs in the config are environment-expanded, so you can keep credentials out
+# of the config, e.g. CLICKHOUSE_PASSWORD referenced as ${CLICKHOUSE_PASSWORD}
+secretEnv: {}
+
+# -- Command arguments
+args: []
+
+config:
+  # -- Logging level: debug, info, warn/warning, or error
+  logging: "info"
+  # -- Metrics server address
+  metricsAddr: ":9090"
+  # -- Health check server address
+  healthCheckAddr: ":8081"
+  clickhouse:
+    # -- Query timeout (standard Go duration)
+    queryTimeout: 30s
+    # -- Dial timeout (standard Go duration)
+    dialTimeout: 5s
+    # -- ClickHouse nodes (required). Each entry is one physical ClickHouse
+    # node, do not use comma-separated failover DSNs or load-balanced
+    # addresses here. DSNs are environment-expanded, so ${CLICKHOUSE_PASSWORD}
+    # injected via secretEnv is supported
+    # @default -- See `values.yaml`
+    nodes:
+      - name: clickhouse-0-0
+        shard: "0"
+        replica: "0"
+        dsn: "clickhouse://default:${CLICKHOUSE_PASSWORD}@clickhouse:9000/default"
+  tiering:
+    # -- Tiering mode. "off" observes only, plan computes decisions without
+    # ALTERs, enforce applies movement/optimization decisions
+    mode: plan
+    # -- Pause between reconcile cycles
+    interval: 5m
+    # -- Defaults copied into every watch that has a tier block. A watch
+    # without a tier block remains observe-only
+    # @default -- See `values.yaml`
+    defaults:
+      # ClickHouse disk name to move cold partitions onto. If omitted it
+      # silently defaults to s3_cache
+      targetDisk: cold_disk
+      # How long a partition must be free of new inserts before it is
+      # eligible for optimize/move
+      quietFor: 24h
+  # -- Tables to watch. A watch without a tier block is observe-only
+  watches: []
+  # - database: default
+  #   table: events_local
+  #   tier:
+  #     age:
+  #       basis: partitionTime
+  #       olderThan: 35d
+  frontend:
+    # -- Enable or disable the frontend UI/API service
+    enabled: true
+    # -- Address to serve the frontend on
+    addr: ":8080"
+
+ingress:
+  http:
+    # -- Ingress resource for the HTTP frontend
+    enabled: false
+    # -- Annotations for Ingress
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # -- Ingress class name
+    className: ""
+    # -- Ingress host
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    # -- Ingress TLS
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+# -- Custom args for the clickhouse-movoor container
+customArgs: []
+
+# -- Command replacement for the clickhouse-movoor container
+customCommand: [] # Only change this if you need to change the default command
+
+service:
+  # -- Service type
+  type: ClusterIP
+
+# -- Update strategy for the StatefulSet
+# @default -- See `values.yaml`
+updateStrategy:
+  type: RollingUpdate
+
+# -- Affinity configuration for pods
+affinity: {}
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+
+# -- Annotations for the StatefulSet
+annotations: {}
+
+# -- Liveness probe
+# @default -- See `values.yaml`
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: probe
+  initialDelaySeconds: 30
+  periodSeconds: 60
+
+# -- Readiness probe
+# @default -- See `values.yaml`
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: probe
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# -- Node selector for pods
+nodeSelector: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Extra Pod ports
+extraPodPorts: []
+
+# -- Pod priority class
+priorityClassName: null
+
+# -- Resource requests and limits
+resources: {}
+# limits:
+#   cpu: 500m
+#   memory: 2Gi
+# requests:
+#   cpu: 300m
+#   memory: 1Gi
+
+# -- The security context for pods
+# @default -- See `values.yaml`
+securityContext:
+  fsGroup: 65532
+  runAsGroup: 65532
+  runAsNonRoot: true
+  runAsUser: 65532
+
+# -- The security context for containers
+# @default -- See `values.yaml`
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  # capabilities:
+  #   drop:
+  #   - ALL
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: false
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- Lifecycle hooks. The default image is distroless, so exec hooks like
+# /bin/sleep are not available
+lifecycle: {}
+
+# -- How long to wait until the pod is forcefully terminated
+terminationGracePeriodSeconds: 60
+
+# -- Tolerations for pods
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# -- Topology Spread Constraints for pods
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: []
+
+# -- Define the PodDisruptionBudget spec
+# If not set then a PodDisruptionBudget will not be created
+podDisruptionBudget: {}
+# minAvailable: 1
+# maxUnavailable: 1
+
+# -- Additional init containers
+initContainers: []
+# - name: my-init-container
+#   image: busybox:latest
+#   command: ['sh', '-c', 'echo hello']
+
+# -- Additional containers
+extraContainers: []
+
+# -- Additional volumes
+extraVolumes: []
+
+# -- Additional volume mounts
+extraVolumeMounts: []
+
+# -- Additional ports. Useful when using extraContainers
+extraPorts: []
+
+# -- Additional env variables
+extraEnv: []
+
+serviceMonitor:
+  # -- If true, a ServiceMonitor CRD is created for a prometheus operator
+  # https://github.com/coreos/prometheus-operator
+  enabled: false
+  # -- Path to scrape
+  path: /metrics
+  # -- Alternative namespace for ServiceMonitor
+  namespace: null
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- Additional ServiceMonitor annotations
+  annotations: {}
+  # -- ServiceMonitor scrape interval
+  interval: 15s
+  # -- ServiceMonitor scheme
+  scheme: http
+  # -- ServiceMonitor TLS configuration
+  tlsConfig: {}
+  # -- ServiceMonitor scrape timeout
+  scrapeTimeout: 30s
+  # -- ServiceMonitor relabelings
+  relabelings: []


### PR DESCRIPTION
## Summary

Adds a new `clickhouse-movoor` chart (v0.0.1) for [clickhouse-movoor](https://github.com/ethpandaops/clickhouse-movoor), the ClickHouse storage tiering operator that watches MergeTree partitions and moves cold ones to a colder disk (e.g. an S3-backed disk).

The chart follows the existing config-file based house pattern (closest sibling: `cbt`): the entire `config:` block in `values.yaml` is rendered into a ConfigMap and mounted at `/config.yaml`, and the binary runs with `--config=/config.yaml`.

## Chart design

- **StatefulSet** (single replica by default) with a paired headless Service, configurable `updateStrategy`, and config/secret checksum pod annotations so pods roll when config changes. No HPA on purpose — movoor is a singleton operator that issues `ALTER TABLE ... MOVE PARTITION` statements; running multiple replicas would conflict.
- **Ports are derived from the config**: helpers parse `metricsAddr` (`:9090`), `healthCheckAddr` (`:8081`) and `frontend.addr` (`:8080`) so container ports, both Services, probes and the ServiceMonitor all follow address overrides automatically. Disabling `config.frontend.enabled` removes the frontend port everywhere.
- **Probes** hit `GET /healthz` on the health check port (movoor's single health endpoint, used for both liveness and readiness).
- **Credentials stay out of the ConfigMap**: movoor environment-expands DSNs, so `secretEnv` values (injected as env vars from a generated Secret) can be referenced as `${CLICKHOUSE_PASSWORD}` in the DSN.
- **Distroless nonroot image defaults**: pod security context uses UID/GID 65532, container has `readOnlyRootFilesystem: true` (the app keeps no on-disk state, so no volumeClaimTemplates needed), and `lifecycle` defaults to empty since the image has no shell for exec hooks.
- Optional **ServiceMonitor** (scrapes the `metrics` port at `/metrics`), **Ingress** for the frontend UI/API, **PodDisruptionBudget** and **ServiceAccount**.
- Chart `README.md` generated with helm-docs v1.5.0; root README chart list updated.

## Default config

Mirrors upstream `config.example.yaml`: one placeholder ClickHouse node, `tiering.mode: plan` (no ALTERs until explicitly switched to `enforce`), and `targetDisk: cold_disk` set explicitly because upstream silently defaults to `s3_cache` when omitted.

## Testing

- `helm lint` and `ct lint` (chart-testing v3.4.0, same as CI) pass; `helm template` verified with defaults and with every optional feature toggled (ServiceMonitor, Ingress, PDB, ServiceAccount, secretEnv, frontend disabled).
- **End-to-end on a local k3d cluster:**
  - Single-node: installed against an in-cluster ClickHouse with the DSN password injected via `secretEnv`. Pod went Ready (readiness = `/healthz` 200 with `status: ok`), metrics served on 9090, frontend UI on 8080, `/api/v1/nodes` showed the node reachable.
  - Multi-node: ran against the upstream `dev/clickhouse-2s2r` compose cluster (2 shards × 2 replicas + keeper + MinIO S3 cold disk) using the dev config in `enforce` mode with the full 18-table watch list. The chart-deployed operator validated all 4 nodes and successfully tiered partitions: `system.parts` showed e.g. 172 active parts on `s3_cache` vs 87 on `default` on shard1-replica1, with similar splits on all nodes; `/healthz` reported `nodesResponded: 4`, and tiering action histograms populated in `/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)