### PR TITLE
feat(chart): StatefulSet support + chart cleanup (0.4.0)

### DIFF
--- a/charts/wagie/Chart.yaml
+++ b/charts/wagie/Chart.yaml
@@ -3,7 +3,7 @@ name: wagie
 description: A modular project orchestration platform
 home: https://github.com/ethpandaops/wagie
 type: application
-version: 0.3.0
+version: 0.4.0
 maintainers:
   - name: samcm
     email: sam.calder-mason@ethereum.org

--- a/charts/wagie/README.md
+++ b/charts/wagie/README.md
@@ -1,6 +1,6 @@
 # wagie
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A modular project orchestration platform
 
@@ -13,7 +13,7 @@ A modular project orchestration platform
 | affinity | object | `{}` | Affinity configuration for pods |
 | annotations | object | `{}` | Annotations for the Deployment |
 | args | list | `[]` | Command arguments |
-| config | object | `{"assistant":{"name":"assistant"},"data-dir":"/data","database":{"dsn":"file:/data/wagie.db","type":"sqlite"},"headquarters":{"http-listen-address":":8080"},"leadership":{"name":"leadership"},"web":{"http-listen-address":":8080"},"worker":{"name":"worker"}}` | Wagie configuration |
+| config | object | `{"data-dir":"/data"}` | Wagie config (/config/config.yaml). Only data-dir set by default; supply the rest per deployment. |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customArgs | list | `[]` | Custom args for the wagie container |
 | customCommand | list | `[]` | Command replacement for the wagie container |
@@ -34,18 +34,21 @@ A modular project orchestration platform
 | ingress.hosts[0].paths | list | `[]` |  |
 | ingress.tls | list | `[]` | Ingress TLS |
 | initContainers | list | `[]` | Additional init containers |
+| kind | string | `"Deployment"` | Workload controller kind: Deployment (default) or StatefulSet |
 | livenessProbe | object | See `values.yaml` | Liveness probe |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | Node selector for pods |
+| persistentVolumeClaimRetentionPolicy | object | `{}` | StatefulSet only: PVC retention policy (whenScaled/whenDeleted). Empty = default Retain/Retain. |
 | podAnnotations | object | `{}` | Pod annotations |
-| podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec If not set then a PodDisruptionBudget will not be created |
 | podLabels | object | `{}` | Pod labels |
+| podManagementPolicy | string | `"OrderedReady"` | StatefulSet only: pod management policy (OrderedReady or Parallel) |
 | priorityClassName | string | `nil` | Pod priority class |
 | readinessProbe | object | See `values.yaml` | Readiness probe |
-| replicas | int | `1` | Number of replicas |
+| replicas | int | `1` | Replicas. Set null to omit the field so an HPA/KEDA owns the count. |
 | resources | object | `{}` | Resource requests and limits |
 | secretEnv | object | `{}` | Secret env variables injected via a created secret |
 | securityContext | object | See `values.yaml` | The security context for pods |
+| service.enabled | bool | `true` | Create a Service. Set false for outbound-only workers (no inbound ports). |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
@@ -60,7 +63,10 @@ A modular project orchestration platform
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
 | serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
 | serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
+| serviceName | string | `""` | StatefulSet only: governing service name (defaults to the chart fullname) |
 | target | string | all | Wagie target modules to run (comma-separated) |
 | terminationGracePeriodSeconds | int | `30` | How long to wait until the pod is forcefully terminated |
 | tolerations | list | `[]` | Tolerations for pods |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pods |
+| updateStrategy | object | `{}` | StatefulSet only: update strategy |
+| volumeClaimTemplates | list | `[]` | StatefulSet only: PVC templates. A `data` template backs /data and persists per ordinal. |

--- a/charts/wagie/ci/ct-values.yaml
+++ b/charts/wagie/ci/ct-values.yaml
@@ -2,22 +2,19 @@ target: all
 
 config:
   data-dir: /data
-
   database:
     type: sqlite
     dsn: "file:/data/wagie.db"
-
+  agents:
+    noop:
+      type: noop
   headquarters:
+    name: ci
     http-listen-address: ":8080"
-
+    public-url: "http://localhost:8080"
+    auth:
+      jwt-secret: ci-test-secret
   worker:
-    name: "worker"
-
-  leadership:
-    name: "leadership"
-
-  assistant:
-    name: "assistant"
-
-  web:
-    http-listen-address: ":8080"
+    name: ci-worker
+    agents: [noop]
+    max-concurrent: 1

--- a/charts/wagie/templates/_helpers.tpl
+++ b/charts/wagie/templates/_helpers.tpl
@@ -62,6 +62,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "wagie.httpPort" -}}
-{{- $addr := index .Values.config.headquarters "http-listen-address" | default ":8080" -}}
-{{ (split ":" $addr)._1 }}
+{{- $addr := dig "headquarters" "http-listen-address" ":8080" .Values.config -}}
+{{- $addr | splitList ":" | last -}}
 {{- end }}

--- a/charts/wagie/templates/_pod.tpl
+++ b/charts/wagie/templates/_pod.tpl
@@ -1,0 +1,139 @@
+{{/* Pod template (metadata + spec) shared by deployment.yaml and statefulset.yaml; include under `template:` with nindent 4. */}}
+{{- define "wagie.podSpec" -}}
+{{- $hasDataVct := false -}}
+{{- range .Values.volumeClaimTemplates }}
+{{- if eq (dig "metadata" "name" "" .) "data" }}{{- $hasDataVct = true }}{{- end }}
+{{- end }}
+metadata:
+  labels:
+    {{- include "wagie.selectorLabels" . | nindent 4 }}
+    {{- with .Values.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    {{- if .Values.secretEnv }}
+    checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+    {{- end }}
+    {{- with .Values.podAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  serviceAccountName: {{ include "wagie.serviceAccountName" . }}
+  {{- with .Values.priorityClassName }}
+  priorityClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.initContainers }}
+  initContainers:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: {{ .Chart.Name }}
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      {{- with .Values.customCommand }}
+      command:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      command:
+        - /usr/local/bin/wagie
+        - --target
+        - {{ .Values.target }}
+        - --config
+        - /config/config.yaml
+        {{- with .Values.args }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.customArgs }}
+      args:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.containerSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumeMounts:
+        - name: config
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+          readOnly: true
+        - name: data
+          mountPath: /data
+        {{- with .Values.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - name: http
+          containerPort: {{ include "wagie.httpPort" . }}
+          protocol: TCP
+        {{- with .Values.extraPodPorts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.livenessProbe }}
+      livenessProbe:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.readinessProbe }}
+      readinessProbe:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        {{- range $key := (.Values.secretEnv | keys | sortAlpha) }}
+        - name: {{ $key }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "wagie.fullname" $ }}-env
+              key: {{ $key }}
+        {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- with .Values.extraContainers }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+  volumes:
+    {{- with .Values.extraVolumes }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    - name: config
+      configMap:
+        name: {{ include "wagie.fullname" . }}
+    {{- if not $hasDataVct }}
+    - name: data
+      emptyDir: {}
+    {{- end }}
+{{- end }}

--- a/charts/wagie/templates/_pod.tpl
+++ b/charts/wagie/templates/_pod.tpl
@@ -45,6 +45,7 @@ spec:
       {{- else }}
       command:
         - /usr/local/bin/wagie
+        - run
         - --target
         - {{ .Values.target }}
         - --config

--- a/charts/wagie/templates/configmap.yaml
+++ b/charts/wagie/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "wagie.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-    {{ toYaml .Values.config | nindent 4 }}
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/wagie/templates/deployment.yaml
+++ b/charts/wagie/templates/deployment.yaml
@@ -1,123 +1,21 @@
+{{- if eq (.Values.kind | default "Deployment") "Deployment" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "wagie.fullname" . }}
   labels:
     {{- include "wagie.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if not (kindIs "invalid" .Values.replicas) }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "wagie.selectorLabels" . | nindent 6 }}
   template:
-    metadata:
-      labels:
-        {{- include "wagie.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-    spec:
-      serviceAccountName: {{ include "wagie.serviceAccountName" . }}
-    {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
-    {{- end }}
-      securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
-      initContainers:
-      {{- if .Values.initContainers }}
-        {{- toYaml .Values.initContainers | nindent 8 }}
-      {{- end }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-        {{- if gt (len .Values.customCommand) 0 }}
-          {{- toYaml .Values.customCommand | nindent 12}}
-        {{- else }}
-          - "/usr/local/bin/wagie"
-          - --target
-          - {{ .Values.target }}
-          - --config
-          - /config/config.yaml
-          {{- if gt (len .Values.args) 0 }}
-          {{- toYaml .Values.args | nindent 12}}
-          {{- end }}
-        {{- end }}
-        {{- if gt (len .Values.customArgs) 0 }}
-        args:
-          {{- toYaml .Values.customArgs | nindent 12}}
-        {{- end }}
-        securityContext:
-          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-        volumeMounts:
-          - name: config
-            mountPath: "/config/config.yaml"
-            subPath: config.yaml
-            readOnly: true
-          - name: data
-            mountPath: /data
-          {{- if .Values.extraVolumeMounts }}
-            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
-          {{- end }}
-        ports:
-          - name: http
-            containerPort: {{ include "wagie.httpPort" . }}
-            protocol: TCP
-          {{- if .Values.extraPodPorts }}
-            {{ toYaml .Values.extraPodPorts | nindent 10 }}
-          {{- end }}
-        livenessProbe:
-          {{- toYaml .Values.livenessProbe | nindent 12 }}
-        readinessProbe:
-          {{- toYaml .Values.readinessProbe | nindent 12 }}
-        resources:
-          {{- toYaml .Values.resources | nindent 12 }}
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        {{- range $key, $value := .Values.secretEnv }}
-        - name: {{ $key }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "wagie.fullname" $ }}-env
-              key: {{ $key }}
-        {{- end }}
-        {{- if .Values.extraEnv }}
-          {{- toYaml .Values.extraEnv | nindent 8 }}
-        {{- end }}
-      {{- if .Values.extraContainers }}
-        {{ toYaml .Values.extraContainers | nindent 8}}
-      {{- end }}
-      nodeSelector:
-        {{- toYaml .Values.nodeSelector | nindent 8 }}
-      affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
-      tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
-      topologySpreadConstraints:
-        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      volumes:
-      {{- if .Values.extraVolumes }}
-        {{ toYaml .Values.extraVolumes | nindent 8}}
-      {{- end }}
-        - name: config
-          configMap:
-            name: {{ include "wagie.fullname" . }}
-        - name: data
-          emptyDir: {}
+    {{- include "wagie.podSpec" . | nindent 4 }}
+{{- end }}

--- a/charts/wagie/templates/secret.yaml
+++ b/charts/wagie/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secretEnv }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,4 +8,5 @@ metadata:
 data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/wagie/templates/service-headless.yaml
+++ b/charts/wagie/templates/service-headless.yaml
@@ -1,0 +1,18 @@
+{{- /* Headless governing Service for the StatefulSet (pod DNS). */}}
+{{- if and (eq (.Values.kind | default "Deployment") "StatefulSet") (not .Values.serviceName) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wagie.fullname" . }}-headless
+  labels:
+    {{- include "wagie.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "wagie.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ include "wagie.httpPort" . }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/wagie/templates/service.yaml
+++ b/charts/wagie/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,12 +8,13 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ include "wagie.httpPort" . }}
+    - name: http
+      port: {{ include "wagie.httpPort" . }}
       targetPort: http
       protocol: TCP
-      name: http
-  {{- if .Values.extraPorts }}
-    {{ toYaml .Values.extraPorts | nindent 4}}
-  {{- end }}
+    {{- with .Values.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     {{- include "wagie.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/wagie/templates/statefulset.yaml
+++ b/charts/wagie/templates/statefulset.yaml
@@ -1,0 +1,35 @@
+{{- if eq (.Values.kind | default "Deployment") "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "wagie.fullname" . }}
+  labels:
+    {{- include "wagie.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not (kindIs "invalid" .Values.replicas) }}
+  replicas: {{ .Values.replicas }}
+  {{- end }}
+  serviceName: {{ .Values.serviceName | default (printf "%s-headless" (include "wagie.fullname" .)) }}
+  podManagementPolicy: {{ .Values.podManagementPolicy | default "OrderedReady" }}
+  {{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "wagie.selectorLabels" . | nindent 6 }}
+  template:
+    {{- include "wagie.podSpec" . | nindent 4 }}
+  {{- with .Values.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/wagie/values.yaml
+++ b/charts/wagie/values.yaml
@@ -4,8 +4,26 @@ nameOverride: ""
 # -- Overrides the chart's computed fullname
 fullnameOverride: ""
 
-# -- Number of replicas
+# -- Replicas. Set null to omit the field so an HPA/KEDA owns the count.
 replicas: 1
+
+# -- Workload controller kind: Deployment (default) or StatefulSet
+kind: Deployment
+
+# -- StatefulSet only: PVC templates. A `data` template backs /data and persists per ordinal.
+volumeClaimTemplates: []
+
+# -- StatefulSet only: pod management policy (OrderedReady or Parallel)
+podManagementPolicy: OrderedReady
+
+# -- StatefulSet only: governing service name (defaults to the chart fullname)
+serviceName: ""
+
+# -- StatefulSet only: update strategy
+updateStrategy: {}
+
+# -- StatefulSet only: PVC retention policy (whenScaled/whenDeleted). Empty = default Retain/Retain.
+persistentVolumeClaimRetentionPolicy: {}
 
 image:
   # -- wagie container image repository
@@ -25,28 +43,9 @@ args: []
 # @default -- all
 target: all
 
-# -- Wagie configuration
+# -- Wagie config (/config/config.yaml). Only data-dir set by default; supply the rest per deployment.
 config:
   data-dir: /data
-
-  database:
-    type: sqlite
-    dsn: "file:/data/wagie.db"
-
-  headquarters:
-    http-listen-address: ":8080"
-
-  worker:
-    name: "worker"
-
-  leadership:
-    name: "leadership"
-
-  assistant:
-    name: "assistant"
-
-  web:
-    http-listen-address: ":8080"
 
 ingress:
   # -- Ingress resource for the HTTP API
@@ -72,6 +71,8 @@ customArgs: []
 customCommand: [] # Only change this if you need to change the default command
 
 service:
+  # -- Create a Service. Set false for outbound-only workers (no inbound ports).
+  enabled: true
   # -- Service type
   type: ClusterIP
 
@@ -161,12 +162,6 @@ tolerations: []
 # -- Topology Spread Constraints for pods
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
 topologySpreadConstraints: []
-
-# -- Define the PodDisruptionBudget spec
-# If not set then a PodDisruptionBudget will not be created
-podDisruptionBudget: {}
-# minAvailable: 1
-# maxUnavailable: 1
 
 # -- Additional init containers
 initContainers: []


### PR DESCRIPTION
## chart 0.4.0 — StatefulSet support + cleanup

### StatefulSet
- New `kind` value renders the workload as `Deployment` (default) or `StatefulSet`. `deployment.yaml` and `statefulset.yaml` share a single pod-template partial (`templates/_pod.tpl`) so the two stay in sync.
- StatefulSet knobs: `volumeClaimTemplates`, `podManagementPolicy`, `serviceName`, `updateStrategy`, `persistentVolumeClaimRetentionPolicy`. A `data` volumeClaimTemplate backs `/data` instead of the default emptyDir.
- A headless governing Service is created automatically for StatefulSets.

### Autoscaling-friendly
- `spec.replicas` is omitted when `replicas: null`, so an HPA/KEDA can own the replica count without it being reset on each apply.

### Service
- `service.enabled` (default `true`) — skip the Service for workloads with no inbound ports.

### Cleanup / fixes
- Optional pod/container fields are gated behind `{{- with }}` — no more empty `nodeSelector: {}` / `securityContext: {}` etc.
- Fixed `extraVolumeMounts` indentation (previously produced invalid YAML).
- The `-env` Secret is only created when `secretEnv` is set.
- Simplified the default `config`, made the http-port helper resilient when no `headquarters` config is present, and dropped the unused `podDisruptionBudget` value.

`helm lint` passes; rendering validated as both a Deployment and a StatefulSet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
